### PR TITLE
Pass along toKey option

### DIFF
--- a/source-source/S3Parallel/S3P.caf
+++ b/source-source/S3Parallel/S3P.caf
@@ -350,6 +350,7 @@ class S3P
             options.toBucket
             options.toFolder
             key
+            toKey
             size: Size
 
           if Size < largeCopyThreshold then s3.copy options else s3.largeCopy options

--- a/source/S3Parallel/S3P.js
+++ b/source/S3Parallel/S3P.js
@@ -707,6 +707,7 @@ Caf.defMod(module, () => {
                     toBucket: options.toBucket,
                     toFolder: options.toFolder,
                     key,
+                    toKey,
                     size: Size,
                   };
                   return (Size < largeCopyThreshold


### PR DESCRIPTION
We saw an issue where our `--to-prefix` argument was being ignored.

After a bit of spelunking, it seems that the toKey function was not getting passed along so it was getting set as the default here:
https://github.com/generalui/s3p/blob/b32ef9170b6eb5c07cca82666c3d93681d6374bd/source-source/S3Parallel/Lib/S3.caf#L142

The fix here seems to fix our error in some initial testing, but I know next to nothing about caffeine script so apologies if there is a better fix!