### PR TITLE
npm install broken in AWS Cloudshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ s3p uses the same credentials aws-cli uses, so see their documentation: https://
 
 # CLI
 
-There is no need to install s3p directly. As long as you have NodeJS installed, you can run s3p directly using `npx`.
+There is no need to install s3p directly. In environments like [AWS Cloudshell](https://aws.amazon.com/cloudshell/) where you have NodeJS installed, you can run s3p directly using `npx`.
 
 The built in help details all the commands, options, and provides many examples:
 


### PR DESCRIPTION
Default npm install syntax is broken in AWS Cloudshell.  I proactively added that Cloudshell supports the npx usage above instead of warning that there would be an error below.

```bash
npm install s3p -g
npm WARN checkPermissions Missing write access to /usr/lib/node_modules
npm ERR! code EACCES
npm ERR! syscall access
npm ERR! path /usr/lib/node_modules
npm ERR! errno -13
npm ERR! Error: EACCES: permission denied, access '/usr/lib/node_modules'
npm ERR!  [Error: EACCES: permission denied, access '/usr/lib/node_modules'] {
npm ERR!   errno: -13,
npm ERR!   code: 'EACCES',
npm ERR!   syscall: 'access',
npm ERR!   path: '/usr/lib/node_modules'
npm ERR! }
```