### PR TITLE
Dont fall back to aws s3 if target key contains a space

### DIFF
--- a/source/S3Parallel/Lib/S3.js
+++ b/source/S3Parallel/Lib/S3.js
@@ -156,7 +156,7 @@ Caf.defMod(module, () => {
             toFolder = temp1.toFolder;
             pretend = temp1.pretend;
             verbose = temp1.verbose;
-            return size >= Caf.pow(1024, 3) || /\s/.test(toKey)
+            return size >= Caf.pow(1024, 3)
               ? this.largeCopy({
                   fromBucket,
                   toBucket,


### PR DESCRIPTION
Fixes #39 